### PR TITLE
Fix Duplicate Class when combined with plugin `react-native-in-app-review` (#28)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,6 +71,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native'
-    implementation 'com.google.android.play:core:1.10.0'
+    implementation 'com.google.android.play:app-update:2.0.1'
+    implementation 'com.google.android.gms:play-services-base:17.5.0'
 }
 

--- a/android/src/main/java/com/agastya/androidinappupdates/AndroidInappUpdateImpl.java
+++ b/android/src/main/java/com/agastya/androidinappupdates/AndroidInappUpdateImpl.java
@@ -19,7 +19,7 @@ import com.google.android.play.core.appupdate.AppUpdateOptions;
 import com.google.android.play.core.install.InstallState;
 import com.google.android.play.core.install.model.InstallStatus;
 import com.google.android.play.core.install.model.UpdateAvailability;
-import com.google.android.play.core.tasks.Task;
+import com.google.android.gms.tasks.Task;
 
 public class AndroidInappUpdateImpl {
     public static final String NAME = "AndroidInappUpdates";


### PR DESCRIPTION
### Description

Dropping implementation in /andriod/build.graddle

`implementation 'com.google.android.play:core:1.10.0'`

Causes an error "Duplicate class com.google.android.play.core.common.IntentSenderForResultStarter" mentioned in #28 

### Test Plan

N/A